### PR TITLE
Custom at rules nesting issues [internal]

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ function atruleChilds (rule, atrule, bubbling) {
     } else if (child.type === 'rule' && bubbling) {
       child.selectors = selectors(rule, child)
     } else if (child.type === 'atrule') {
-      atruleChilds(rule, child, bubbling)
+      if (child.nodes) {
+        atruleChilds(rule, child, bubbling)
+      } else {
+        children.push(child)
+      }
     }
   })
   if (bubbling) {

--- a/index.js
+++ b/index.js
@@ -66,30 +66,32 @@ function pickComment (comment, after) {
   }
 }
 
-function atruleChilds (rule, atrule, bubbling) {
-  let children = []
-  atrule.each(child => {
-    if (child.type === 'comment') {
-      children.push(child)
-    } else if (child.type === 'decl') {
-      children.push(child)
-    } else if (child.type === 'rule' && bubbling) {
-      child.selectors = selectors(rule, child)
-    } else if (child.type === 'atrule') {
-      if (child.nodes) {
-        atruleChilds(rule, child, bubbling)
-      } else {
+function createFnAtruleChilds (bubble) {
+  return function atruleChilds (rule, atrule, bubbling) {
+    let children = []
+    atrule.each(child => {
+      if (child.type === 'comment') {
         children.push(child)
+      } else if (child.type === 'decl') {
+        children.push(child)
+      } else if (child.type === 'rule' && bubbling) {
+        child.selectors = selectors(rule, child)
+      } else if (child.type === 'atrule') {
+        if (child.nodes && bubble[child.name]) {
+          atruleChilds(rule, child, true)
+        } else {
+          children.push(child)
+        }
       }
-    }
-  })
-  if (bubbling) {
-    if (children.length) {
-      let clone = rule.clone({ nodes: [] })
-      for (let child of children) {
-        clone.append(child)
+    })
+    if (bubbling) {
+      if (children.length) {
+        let clone = rule.clone({ nodes: [] })
+        for (let child of children) {
+          clone.append(child)
+        }
+        atrule.prepend(clone)
       }
-      atrule.prepend(clone)
     }
   }
 }
@@ -124,6 +126,7 @@ function atruleNames (defaults, custom) {
 
 module.exports = (opts = {}) => {
   let bubble = atruleNames(['media', 'supports'], opts.bubble)
+  let atruleChilds = createFnAtruleChilds(bubble)
   let unwrap = atruleNames(
     [
       'document',

--- a/index.test.js
+++ b/index.test.js
@@ -94,11 +94,18 @@ it('unwraps at-rules with interleaved properties', () => {
   )
 })
 
-it('do not move custom at-rules', () => {
+it('does not move custom at-rules', () => {
   run(
-    '.one { @mixin test; } .two { @media screen { @mixin test; } } .three { @phone { color: black } }',
-    '.one { @mixin test; } @media screen { .two { @mixin test } } @phone { .three { color: black } }',
+    '.one { @mixin test; } .two { @media screen { @mixin test; } } .three { @media screen { @mixin test { color: black } } } .four { @phone { color: black } }',
+    '.one { @mixin test; } @media screen { .two { @mixin test } } @media screen { .three { @mixin test { color: black } } } @phone { .four { color: black } }',
     { bubble: ['phone'] }
+  )
+})
+
+it('does not move custom at-rules placed under nested bubbling ones', () => {
+  run(
+    '.one { @supports (color: black) { @media screen { @mixin test; } } } .two { @supports (color: black) { @media screen { @mixin test { color: black } } } }',
+    '@supports (color: black) { @media screen {.one { @mixin test } } } @supports (color: black) { @media screen { .two { @mixin test { color: black } } } }'
   )
 })
 

--- a/index.test.js
+++ b/index.test.js
@@ -96,8 +96,8 @@ it('unwraps at-rules with interleaved properties', () => {
 
 it('do not move custom at-rules', () => {
   run(
-    '.one { @mixin test; } .two { @phone { color: black } }',
-    '.one { @mixin test; } @phone { .two { color: black } }',
+    '.one { @mixin test; } .two { @media screen { @mixin test; } } .three { @phone { color: black } }',
+    '.one { @mixin test; } @media screen { .two { @mixin test } } @phone { .three { color: black } }',
     { bubble: ['phone'] }
   )
 })


### PR DESCRIPTION
This fixes issues related to custom at rule nesting:

**Input 1 (bubbling up custom childless at-rules):**
```css
@media screen { .two { @mixin test } }
```

Expected output:
```css
@media screen { .two { @mixin test } }
```

Actual output:
```css
@media screen { @mixin test; }
```
<br>

**Input 2 (bubbling up all at-rules, ignoring the option setting):**
```css
@media screen { .three { @mixin test { color: black } } }
```

Expected output:
```css
@media screen { .three { @mixin test { color: black } } }
```

Actual output:
```css
actual: @media screen { @mixin test { .three { color: black } } }
```
